### PR TITLE
create script which merges count data into the db

### DIFF
--- a/migrations/20201115230456-create-user.js
+++ b/migrations/20201115230456-create-user.js
@@ -1,32 +1,33 @@
-'use strict';
+"use strict";
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.createTable('Users', {
+    await queryInterface.createTable("Users", {
       id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       discordId: {
         allowNull: false,
-        type: Sequelize.STRING
+        unique: true,
+        type: Sequelize.STRING,
       },
       count: {
         defaultValue: 0,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
   },
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.dropTable('Users');
-  }
+    await queryInterface.dropTable("Users");
+  },
 };

--- a/models/user.js
+++ b/models/user.js
@@ -1,7 +1,5 @@
-'use strict';
-const {
-  Model
-} = require('sequelize');
+"use strict";
+const { Model } = require("sequelize");
 module.exports = (sequelize, DataTypes) => {
   class User extends Model {
     /**
@@ -12,19 +10,23 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       // define association here
     }
-  };
-  User.init({
-    discordId: {
+  }
+  User.init(
+    {
+      discordId: {
         type: DataTypes.STRING,
-        allowNull: false
-    },
-    count: { 
+        allowNull: false,
+        unique: true,
+      },
+      count: {
         type: DataTypes.INTEGER,
-        defaultValue: 0
+        defaultValue: 0,
+      },
+    },
+    {
+      sequelize,
+      modelName: "User",
     }
-  }, {
-    sequelize,
-    modelName: 'User',
-  });
+  );
   return User;
 };

--- a/scripts/countMerge.js
+++ b/scripts/countMerge.js
@@ -10,15 +10,10 @@ const mergeUsers = async () => {
     const filePath = `${userFileLocation}/${user}`;
     const data = fs.readFileSync(filePath);
     const count = JSON.parse(data);
-    const userInstance = await userModel
+    await userModel
       .create({
         discordId: user.split(".")[0],
-        count: Object.values(count),
-      })
-      .then(() => {
-        console.log(
-          `inserted - id: ${userInstance.discordId}, count: ${userInstance.count}`
-        );
+        count: count.count,
       })
       .catch((err) => {
         console.error(err);

--- a/scripts/countMerge.js
+++ b/scripts/countMerge.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const db = require("../models").sequelize;
+const userModel = db.models.User;
+const userFileLocation = "users";
+
+const mergeUsers = async () => {
+  let users = fs.readdirSync(userFileLocation);
+  users = users.filter((e) => e.match(/.*\.json/gi));
+  for (const user of users) {
+    const filePath = `${userFileLocation}/${user}`;
+    const data = fs.readFileSync(filePath);
+    const count = JSON.parse(data);
+    const userInstance = await userModel
+      .create({
+        discordId: user.split(".")[0],
+        count: Object.values(count),
+      })
+      .then(() => {
+        console.log(
+          `inserted - id: ${userInstance.discordId}, count: ${userInstance.count}`
+        );
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+};
+
+mergeUsers();


### PR DESCRIPTION
updated both ```models/user.js``` and the ```create-user.js``` migration:
- added a unique constraint on ```discordId``` in order to prevent duplicate users

added ```scripts/countMerge.js```:
- a script which merges the old, json-based data for the ```!count``` command into the sqlite database
- in order to run it, just run ```node ./scripts/countMerge.js```