### PR TITLE
Add command throttling service

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ client.on("message", (msg) => {
   if (!client.commands.has(command)) return;
 
   /**
+   * This place is reserved for another service in the chain: CommandWhitelistingService
+   * This service should filter the command before ChannelBinding and Throttling
+   */
+
+  /**
    * Automatically checks if the requested command can be executed in the channel
    * this message came from.
    * 

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -91,13 +91,13 @@ class CommandThrottling {
 
       // Get the defined .env command throttling
       // Matching COMMAND_THROTTLING_<command_name>
-      let throttling = process.env[option];
+      let throttling = parseInt(process.env[option], 10);
       
       // Ignore if, for some reason, the throttling had no time specified,
       // is NaN or undefined. To apply command throttling properly, we can only
       // accept numbers
-      if (throttling === "" || throttling === undefined || isNaN(throttling) === true) {
-        return true;
+      if (isNaN(throttling) === true) {
+        return;
       }
 
       // The command has been defined correctly, add it to the list

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -32,7 +32,7 @@ class CommandThrottling {
     this.envCommandPart = "COMMAND_THROTTLING_";
 
     /**
-     * COmbination of <envCommandPart> and <command>
+     * Combination of <envCommandPart> and <command>
      *
      * @var {string}
      */

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -7,6 +7,24 @@
 class CommandThrottling {
   static currentThrottles = {};
 
+  /**
+   * Returns the remaining cooldown in seconds for the current command / user
+   *
+   * @param   {string}  command  Executed command
+   * @param   {string}  user     Message owner
+   *
+   * @return  {float}
+   */
+  static getRemainingCooldown = (command, user) => {
+    const cooldown = CommandThrottling.currentThrottles[command][user];
+
+    // The command should exist. Return zero if it's not defined
+    if (cooldown === undefined) {
+      return 0;
+    }
+
+    return (cooldown - Date.now()) / 1000;
+  }
   constructor(command, owner) {
     /**
      * Executed command name. Already processed by Channel Binding as

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -1,0 +1,152 @@
+/**
+ * Command Throttling defines the cooldown for each command __for each user__
+ * The same command can be executed by many users - later handled by Discord - 
+ * but the same command can not be executed by the same user multiple times
+ * until the cooldown ends.
+ */
+class CommandThrottling {
+  static currentThrottles = {};
+
+  constructor(command, owner) {
+    /**
+     * Executed command name. Already processed by Channel Binding as
+     * command name without exclamation mark
+     *
+     * @var {string}
+     */
+    this.command = command;
+
+    /**
+     * Discord user that executed this command
+     *
+     * @var {string}
+     */
+    this.messageOwner = owner;
+
+    /**
+     * String partial to match during the command lookup.
+     * Environment bindings should follow this convention
+     *
+     * @var {string}
+     */
+    this.envCommandPart = "COMMAND_THROTTLING_";
+
+    /**
+     * Object of commands defined in the .env that has to be throttled
+     *
+     * @var {object}
+     */
+    this.commandsToThrottle = this.fetchCommandsToThrottle();
+  }
+
+  /**
+   * Extract the commands to throttle
+   *
+   * @return  {object}
+   */
+  fetchCommandsToThrottle = () => {
+    const options = Object.keys(process.env);
+    let commands = {};
+    let commandComparison = this.envCommandPart + this.command;
+    
+    options.forEach((option) => {
+      // Ignore the mismatch
+      if (option != commandComparison) {
+        return;
+      }
+
+      // Get the defined .env command throttling
+      let throttling = process.env[option];
+      
+      // Ignore if, for some reason, the throttling had no time specified,
+      // is NaN or undefined. To apply command throttling properly, we can only
+      // accept 
+      if (throttling === "" || throttling === undefined || isNaN(throttling) === true) {
+        return true;
+      }
+
+      // The command has been defined correctly, add it to the list
+      commands[option] = { cooldown: throttling };
+    });
+
+    return commands;
+  }
+
+  /**
+   * Checks if the current command has throttling defined in the .env
+   * We already have a list of commands from the constructor, so we only have
+   * to check for the presence in the class field
+   *
+   * @return  {boolean}
+   */
+  canBeThrottled = () => {
+    return this.commandsToThrottle[this.envCommandPart + this.command.toUpperCase()] !== undefined
+  }
+
+  /**
+   * Checks if the current command exists on the list of currently throttled
+   * commands under the key of the owner of this message.
+   * If it exists, checks if its cooldown has ended for this user
+   *
+   * @return  {boolean}
+   */
+  isCurrentlyThrottled = () => {
+    let throttledCommand = CommandThrottling.currentThrottles[this.command];
+
+    // The user is allowed to execute this command if it's not on the list yet
+    if (throttledCommand === undefined) {
+      return false;
+    }
+
+    // We have to check if it's on cooldown for the current user
+    // If it's still on cooldown, we will reject the execution
+    let cooldown = throttledCommand[this.messageOwner];
+    let time = Date.now();
+    if ((cooldown - time) > 0) {
+      return true;
+    }
+
+    // The negative cooldown means we are good to go, we can remove the
+    // current user from the list in this command
+    delete throttledCommand[this.messageOwner];
+
+    // NOTICE: we can leave the command in the map as it will get overwritten
+    return false;
+  }
+
+  throttleCommand = () => {
+    // Get the command cooldown we fetched earlier from the .env
+    // Convert the cooldown to milliseconds and add it to the current time
+    let commandCooldown = Date.now() + this.commandsToThrottle[this.envCommandPart + this.command].cooldown * 1000;
+
+    // Set a cooldown for this command for the current user
+    CommandThrottling.currentThrottles[this.command] = { [this.messageOwner]: commandCooldown };
+  }
+
+  /**
+   * Checks if the command is currently throttled. If the command can not be 
+   * executed by this user at the moment, we will ignore the execution to not 
+   * clog the queue, so other users are able to use this/other commands.
+   *
+   * @return  {boolean}
+   */
+  canBeExecuted = () => {
+    // If there was no throttling defined, ignore
+    if (this.canBeThrottled() === false) {
+      return true;
+    }
+
+    if (this.isCurrentlyThrottled() === true) {
+      return false;
+    }
+
+    // If this command is not currently throttled and is not on cooldown for
+    // this user, add it to the list / overwrite it
+    this.throttleCommand();
+    return true;
+  }
+}
+
+module.exports = {
+  CommandThrottling,
+};

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -32,6 +32,13 @@ class CommandThrottling {
     this.envCommandPart = "COMMAND_THROTTLING_";
 
     /**
+     * COmbination of <envCommandPart> and <command>
+     *
+     * @var {string}
+     */
+    this.envCommandDefinition;
+
+    /**
      * Object of commands defined in the .env that has to be throttled
      *
      * @var {object}
@@ -47,11 +54,11 @@ class CommandThrottling {
   fetchCommandsToThrottle = () => {
     const options = Object.keys(process.env);
     let commands = {};
-    let commandComparison = this.envCommandPart + this.command;
+    this.envCommandDefinition = this.envCommandPart + this.command;
     
     options.forEach((option) => {
       // Ignore the mismatch
-      if (option != commandComparison) {
+      if (option != this.envCommandDefinition) {
         return;
       }
 
@@ -81,7 +88,7 @@ class CommandThrottling {
    * @return  {boolean}
    */
   canBeThrottled = () => {
-    return this.commandsToThrottle[this.envCommandPart + this.command.toUpperCase()] !== undefined
+    return this.commandsToThrottle[this.envCommandDefinition.toUpperCase()] !== undefined
   }
 
   /**
@@ -124,7 +131,7 @@ class CommandThrottling {
   throttleCommand = () => {
     // Get the command cooldown we fetched earlier from the .env
     // Convert the cooldown to milliseconds and add it to the current time
-    let commandCooldown = Date.now() + this.commandsToThrottle[this.envCommandPart + this.command].cooldown * 1000;
+    let commandCooldown = Date.now() + this.commandsToThrottle[this.envCommandDefinition].cooldown * 1000;
 
     // Set a cooldown for this command for the current user
     CommandThrottling.currentThrottles[this.command] = { [this.messageOwner]: commandCooldown };

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -56,11 +56,12 @@ class CommandThrottling {
       }
 
       // Get the defined .env command throttling
+      // Matching COMMAND_THROTTLING_<command_name>
       let throttling = process.env[option];
       
       // Ignore if, for some reason, the throttling had no time specified,
       // is NaN or undefined. To apply command throttling properly, we can only
-      // accept 
+      // accept numbers
       if (throttling === "" || throttling === undefined || isNaN(throttling) === true) {
         return true;
       }
@@ -90,7 +91,7 @@ class CommandThrottling {
    *
    * @return  {boolean}
    */
-  isCurrentlyThrottled = () => {
+  isOnCooldown = () => {
     let throttledCommand = CommandThrottling.currentThrottles[this.command];
 
     // The user is allowed to execute this command if it's not on the list yet
@@ -110,7 +111,7 @@ class CommandThrottling {
     // current user from the list in this command
     delete throttledCommand[this.messageOwner];
 
-    // NOTICE: we can leave the command in the map as it will get overwritten
+    // NOTICE: we can leave the command on the list as it will get overwritten
     return false;
   }
 
@@ -136,7 +137,7 @@ class CommandThrottling {
       return true;
     }
 
-    if (this.isCurrentlyThrottled() === true) {
+    if (this.isOnCooldown() === true) {
       return false;
     }
 

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -3,6 +3,10 @@
  * The same command can be executed by many users - later handled by Discord - 
  * but the same command can not be executed by the same user multiple times
  * until the cooldown ends.
+ *
+ * Ideally the command should have a cooldown set to > 0 (integer) or it will have no effect
+ * on this command at all - it won't be throttled since the 0-cooldown will make it
+ * immediately available anyway and 0.5s cooldown makes no sense ¯\_(ツ)_/¯
  */
 class CommandThrottling {
   static currentThrottles = {};
@@ -25,6 +29,11 @@ class CommandThrottling {
 
     return (cooldown - Date.now()) / 1000;
   }
+
+  /**
+   * @param   {string}  command  Command name
+   * @param   {string}  owner    Username
+   */
   constructor(command, owner) {
     /**
      * Executed command name. Already processed by Channel Binding as
@@ -57,7 +66,7 @@ class CommandThrottling {
     this.envCommandDefinition;
 
     /**
-     * Object of commands defined in the .env that has to be throttled
+     * Object of commands defined in the .env that have to be throttled
      *
      * @var {object}
      */

--- a/services/commandThrottlingService.js
+++ b/services/commandThrottlingService.js
@@ -1,5 +1,5 @@
 /**
- * Command Throttling defines the cooldown for each command __for each user__
+ * Command Throttling defines the cooldown and for each command __for each user__
  * The same command can be executed by many users - later handled by Discord - 
  * but the same command can not be executed by the same user multiple times
  * until the cooldown ends.
@@ -115,6 +115,12 @@ class CommandThrottling {
     return false;
   }
 
+  /**
+   * Add this command to the list and set a cooldown for the message owner
+   * to prevent the command execution
+   *
+   * @return  {void}
+   */
   throttleCommand = () => {
     // Get the command cooldown we fetched earlier from the .env
     // Convert the cooldown to milliseconds and add it to the current time
@@ -137,6 +143,7 @@ class CommandThrottling {
       return true;
     }
 
+    // Reject the command execution if this command is on cooldown
     if (this.isOnCooldown() === true) {
       return false;
     }

--- a/test/commandThrottlingService.test.js
+++ b/test/commandThrottlingService.test.js
@@ -32,7 +32,7 @@ const injectTestThrottling = (value = testCommandCooldown) => {
 }
 
 describe("Channel Throttling Service", () => {
-  afterEach("restore .env and the sandbox", () => {
+  afterEach("restore .env", () => {
     process.env = env;
   });
 

--- a/test/commandThrottlingService.test.js
+++ b/test/commandThrottlingService.test.js
@@ -2,7 +2,7 @@ const expect = require("chai").expect;
 const { CommandThrottling } = require("../services/commandThrottlingService");
 const commandThrottlingService = require("../services/commandThrottlingService").CommandThrottling;
 
-// This will restore to the origibna
+// This will restore to the original state
 const env = Object.assign({}, process.env);
 
 // We have to assume this key will exist in the .env

--- a/test/commandThrottlingService.test.js
+++ b/test/commandThrottlingService.test.js
@@ -1,0 +1,157 @@
+const expect = require("chai").expect;
+const { CommandThrottling } = require("../services/commandThrottlingService");
+const commandThrottlingService = require("../services/commandThrottlingService").CommandThrottling;
+
+// This will restore to the origibna
+const env = Object.assign({}, process.env);
+
+// We have to assume this key will exist in the .env
+const testCommandThrottle = "COMMAND_THROTTLING_TEST";
+const testCommandName = "TEST";
+const testCommandCooldown = 3;
+const testUsername = "TestUser";
+
+/**
+ * Shortcut for new Command Throttling instance
+ *
+ * @return  {CommandThrottling}
+ */
+const newService = () => {
+  return new commandThrottlingService(testCommandName, testUsername);
+}
+
+/**
+ * Adds a test command throttling key to the .env
+ *
+ * @param   {any}   value   Command Throttling cooldown. For testing purposes it can hold any value
+ *
+ * @return  {void}
+ */
+const injectTestThrottling = (value = testCommandCooldown) => {
+  process.env[testCommandThrottle] = value;
+}
+
+describe("Channel Throttling Service", () => {
+  afterEach("restore .env and the sandbox", () => {
+    process.env = env;
+  });
+
+  describe("Throttling Setup", () => {
+    it ("should fetch the existing command throttling key from the .env", () => {
+      // Inject the test command
+      injectTestThrottling();
+  
+      // Create a new instance with test command name and a username
+      // Command throttling comes after the channel binding, and it yields
+      // the processed command name as an UpperCase string
+      const throttlingService = newService();
+  
+      // We will check if the test command has been fetched correctly
+      const fetchedThrottles = Object.keys(throttlingService.commandsToThrottle);
+  
+      expect(fetchedThrottles.includes(testCommandThrottle)).to.be.deep.equal(true);
+    });
+  
+    /**
+     * This test implies the command throttling key is commented (undefined)
+     */
+    it ("should not find a test command in fetched throttles", () => {
+      const throttlingService = newService();
+      const fetchedThrottles = Object.keys(throttlingService.commandsToThrottle);
+  
+      expect(fetchedThrottles.includes(testCommandThrottle)).to.be.deep.equal(false);
+    });
+  
+    /**
+     * In this test the command throttling is defined, but with invalid values,
+     * so those commands should not be included in the throttling
+     */
+    const invalidValues = ["", "test", [], {}];
+    invalidValues.forEach((value) => {
+      it (`should not find a test command in the fetched throttles with invalid value specified in the .env (${typeof value} / ${value})`, () => {
+        // Inject the invalid value
+        // This command should not be included when user specifies an invalid value
+        injectTestThrottling(value);
+  
+        const throttlingService = newService();
+        const fetchedThrottles = Object.keys(throttlingService.commandsToThrottle);
+        
+        expect(fetchedThrottles.includes(testCommandThrottle)).to.be.deep.equal(false);
+      });
+    });
+  });
+
+  describe("Throttling Application", () => {
+    it ("should set a cooldown on executed command", () => {
+      injectTestThrottling();
+
+      const throttlingService = newService();
+
+      // This assumes we executed the command since the allowed commands have
+      // cooldown applied
+      throttlingService.throttleCommand();
+
+      // We have already tested against the absence of the throttled command
+      // so we can jump right into checking the command cooldown.
+      // At this point, the cooldown __should__ be positive.
+      const remainingCooldown = CommandThrottling.getRemainingCooldown(testCommandName, testUsername);
+
+      expect(remainingCooldown).to.be.greaterThan(0);
+    });
+
+    /**
+     * Applies a fixed cooldown of 1 second and checks if the command was rejected
+     */
+    it ("should reject a command on cooldown", () => {
+      injectTestThrottling(1);
+
+      const throttlingService = newService();
+      throttlingService.throttleCommand();
+
+      // .canBeExecuted() should return false since we have applied a one second
+      // cooldown on the test command
+      expect(throttlingService.canBeExecuted()).to.be.deep.equal(false);
+    });
+
+    /**
+     * This object contains the awaiting times and the expected test result
+     * In this test we are applying a fixed cooldown of __one second__ and
+     * after that time the command execution should be allowed.
+     *
+     * We also have to cover the attempt where the cooldown has not ended yet,
+     * so after 900 milliseconds we should still not be able to execute this command.
+     */
+    const executions = {
+      /* After this awaiting time the test should pass */
+      allow: [1000, true],
+      /* After this awaiting time the test should fail */
+      disallow: [900, false],
+    };
+
+    /**
+     * Applies a fixed cooldown of 1 second and waits until the cooldown has ended
+    */
+    for (const execution in executions) {
+      const testCooldown = executions[execution][0];
+      const expectedResult = executions[execution][1];
+
+      it (`(async test) should ${execution} the command execution after ${testCooldown} milliseconds`, async () => {
+        injectTestThrottling(1);
+
+        const throttlingService = newService();
+        throttlingService.throttleCommand();
+
+        let cooldown = new Promise( (resolve, reject) => {
+          setTimeout(() => {
+            // After we applied one second cooldown, the service should return
+            // true the next time we check if the command can be executed
+            resolve(throttlingService.canBeExecuted());
+          }, testCooldown);
+        });
+
+        const cooldownState = await cooldown;
+        expect(cooldownState).to.be.deep.equal(expectedResult);
+      });
+   };
+  });
+});


### PR DESCRIPTION
When defined in the `.env`, will reject the command execution allowing other users to execute their commands (or the same command) without hitting the rate limit by one user spamming the same command over and over

Define as following:

```
COMMAND_THROTTLING_<command_name>=<value>
# e.g. COMMAND_THROTTLING_STATS=3
```

Commands requested by one user in a row
```
!stats -> executed
!stats -> rejected
!stats -> rejected
!stats -> rejected
!stats -> rejected
!dice -> executed
```

![image](https://user-images.githubusercontent.com/7021295/103143939-79a03480-4720-11eb-98b8-da9f2cb60ced.png)
